### PR TITLE
fix 'CosmosClient' import error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,6 +54,8 @@ resource "null_resource" "file_populate_data" {
   provisioner "local-exec" {
     command     = <<EOF
 sed -i 's/AZURE_FUNCTION_URL/${azurerm_storage_account.storage_account.name}\.blob\.core\.windows\.net\/${azurerm_storage_container.storage_container_prod.name}/g' modules/module-1/resources/cosmosdb/blog-posts.json
+python3 -m venv azure-goat-environment
+source azure-goat-environment/bin/activate
 pip3 install --pre azure-cosmos
 python3 modules/module-1/resources/cosmosdb/create-table.py
 EOF


### PR DESCRIPTION
Running "terraform apply" on Ubuntu 20.04 with python 3.8 I got the following error: ...
ImportError: cannot import name 'CosmosClient' from 'azure.cosmos' ...

My system has an Azure cosmos package already installed but with a different version,  so this seems to create a conflict.   Following the official guide (https://pypi.org/project/azure-cosmos/) I tried to configure a virtual environment first and that fixed the issue. 

I would suggest to execute the python command always in a dedicated virtual env to avoid this and future issues.